### PR TITLE
Update version to 0.1.2 and document changes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,10 @@ MIT License - see LICENSE file for details.
 
 ## Changelog
 
-### 0.1.1
+### 0.1.2 (06-29-2025)
+- Update sql_helper.py
+
+### 0.1.1 (06-28-2025)
 - Refactored `detect_statement_type` into smaller, modular helper functions for clarity and maintainability.
 - Improved code readability and reduced duplication in SQL type detection logic.
 - Added comprehensive tests for complex, nested, malformed, and database-specific SQL cases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jpy-sql-runner"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Python utility for executing SQL files against databases"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This pull request updates the `jpy-sql-runner` project to version 0.1.2 and introduces several improvements to the `sql_helper.py` module. Key changes include enhanced type annotations for better code clarity, stricter validation for input parameters, and expanded support for handling file paths. Additionally, documentation updates reflect these enhancements.

### Enhancements to type annotations:
* Added type annotations to multiple helper functions in `sql_helper.py` to improve code clarity and maintainability. Examples include `_is_fetch_statement`, `_find_first_dml_keyword_top_level`, and `_extract_tokens_after_with`. [[1]](diffhunk://#diff-a807a75d80cb7458f9d5e645650d4d850a06eb5f06e7cb7078bec0c5ef89706dL53-R55) [[2]](diffhunk://#diff-a807a75d80cb7458f9d5e645650d4d850a06eb5f06e7cb7078bec0c5ef89706dL103-R105) [[3]](diffhunk://#diff-a807a75d80cb7458f9d5e645650d4d850a06eb5f06e7cb7078bec0c5ef89706dL268-R270)

### Improved file path handling:
* Updated `split_sql_file` to support both `str` and `Path` objects for file paths, adding stricter validation for input parameters. [[1]](diffhunk://#diff-a807a75d80cb7458f9d5e645650d4d850a06eb5f06e7cb7078bec0c5ef89706dL415-R417) [[2]](diffhunk://#diff-a807a75d80cb7458f9d5e645650d4d850a06eb5f06e7cb7078bec0c5ef89706dR433-L436)

### Documentation updates:
* Updated the README to reflect the new version (0.1.2) and added details about the updated `sql_helper.py` module.
* Bumped the project version to 0.1.2 in `pyproject.toml`.